### PR TITLE
Build fixes and make makepkg honor proxy settings

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -8,7 +8,6 @@ INSTALLDIR="$1"
 DISTRO="$2"  # aka elsewhere as $DIST
 
 BOOTSTRAP_DIR="${CACHEDIR}/bootstrap"
-PROXY_ENV="http_proxy=${REPO_PROXY:-${http_proxy}}"
 PACMAN_MIRROR="${PACMAN_MIRROR:-mirror.rackspace.com}"
 
 PACMAN_CACHE_DIR="${CACHEDIR}/pacman_cache"
@@ -45,7 +44,8 @@ echo "  --> Initializing pacman keychain..."
 
 echo "  --> Installing core pacman packages..."
 export PACMAN_CACHE_MOUNT_DIR="${BOOTSTRAP_DIR}/mnt/var/cache/pacman"
-"${SCRIPTSDIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/sh -c "$PROXY_ENV pacstrap /mnt base"
+"${SCRIPTSDIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/sh -c \
+    "http_proxy='${REPO_PROXY}' pacstrap /mnt base"
 unset PACMAN_CACHE_MOUNT_DIR
 
 echo "  --> Removing non-required linux kernel (can be added manually through a package)..."

--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -44,6 +44,10 @@ if ! [ -d "${INSTALLDIR}/home/user" ]; then
     echo "  --> Synchronize resolv.conf..."
     cp /etc/resolv.conf "${INSTALLDIR}/etc/resolv.conf"
 
+    # Checking for free disk free space doesn't work in chroots
+    echo "  --> Comment out CheckSpace in pacman.conf..."
+    sed 's/^ *CheckSpace/#CheckSpace/g' -i "${INSTALLDIR}/etc/pacman.conf"
+
     echo "  --> Installing required makepkg dependencies..."
     pkgs="binutils fakeroot sudo"
     "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \

--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -53,8 +53,13 @@ if ! [ -d "${INSTALLDIR}/home/user" ]; then
     "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
         "pacman -Sy --needed --noconfirm --asdeps $pkgs"
 
+    # makepkg internally calls sudo without '-E', so we need to add an
+    # env_keep to honor proxy settings
     echo "  --> Configure sudo..."
-    echo '%wheel ALL=(ALL) NOPASSWD: ALL' > "${INSTALLDIR}/etc/sudoers.d/qubes-build-user"
+    cat > "${INSTALLDIR}/etc/sudoers.d/qubes-build-user" <<EOF
+Defaults env_keep += "http_proxy https_proxy ftp_proxy"
+%wheel ALL=(ALL) NOPASSWD: ALL
+EOF
 
     # Note: Enable x86 repos
     tee -a "${INSTALLDIR}/etc/pacman.conf" <<EOF

--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -51,7 +51,7 @@ if ! [ -d "${INSTALLDIR}/home/user" ]; then
     echo "  --> Installing required makepkg dependencies..."
     pkgs="binutils fakeroot sudo"
     "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
-        "pacman -Sy --needed --noconfirm --asdeps $pkgs"
+        "http_proxy='${REPO_PROXY}' pacman -Sy --needed --noconfirm --asdeps $pkgs"
 
     # makepkg internally calls sudo without '-E', so we need to add an
     # env_keep to honor proxy settings

--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -18,10 +18,8 @@ mkdir -p "${CACHEDIR}/pacman_cache"
 
 echo "  --> Downloading Archlinux bootstrap tarball (v${ARCHLINUX_REL_VERSION})..."
 
-# wget should honor an exported $http_proxy env value
-# XXX: Should we honor $REPO_PROXY here?
-wget -N -P "$CACHEDIR" "$BOOTSTRAP_URL"
-wget -N -P "$CACHEDIR" "${BOOTSTRAP_URL}.sig"
+http_proxy="$REPO_PROXY" wget -N -P "$CACHEDIR" "$BOOTSTRAP_URL"
+http_proxy="$REPO_PROXY" wget -N -P "$CACHEDIR" "${BOOTSTRAP_URL}.sig"
 
 echo "  --> Preparing GnuPG to verify tarball..."
 mkdir -p "${CACHEDIR}/gpghome"

--- a/scripts/02_install_groups.sh
+++ b/scripts/02_install_groups.sh
@@ -25,4 +25,4 @@ export PACMAN_CACHE_DIR
 echo "  --> Installing archlinux package groups..."
 echo "    --> Selected packages: ${PKGGROUPS}"
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
-    "http_proxy=${REPO_PROXY} pacman -S --needed --noconfirm ${PKGGROUPS}"
+    "http_proxy='${REPO_PROXY}' pacman -S --needed --noconfirm ${PKGGROUPS}"

--- a/scripts/packages.list
+++ b/scripts/packages.list
@@ -1,25 +1,53 @@
+# X
 xorg
 xterm
+
+# Need Python2 for Qubes
 python2
-artwiz-fonts
+
+# Basic utils
 ethtool
-font-bitstream-speedo
 net-tools
 sudo
+wget
+
+# User env
+ldns
+tmux
+vim
+zsh
+
+# Fonts
+artwiz-fonts
+font-bitstream-speedo
 ttf-dejavu
 ttf-freefont
-wget
-zsh
+ttf-inconsolata
+ttf-linux-libertine
+# Particularly good Unicode coverage:
+noto-fonts
+ttf-symbola
+
+# Needed for netvms
 networkmanager
 network-manager-applet
-linux-firmware
+
+# Gnome
 gnome-settings-daemon
+gtk-engines
 gvfs
 lxappearance
-gtk-engines
-firefox
-thunderbird
-xfce4-terminal
+
+# XFCE
 leafpad
 thunar
 thunar-volman
+xfce4-terminal
+
+# Major "productivity" applications
+evince
+firefox
+thunderbird
+
+# Hardening-related
+checksec

--- a/scripts/packages_minimal.list
+++ b/scripts/packages_minimal.list
@@ -1,8 +1,15 @@
+# X
 xorg
 xterm
+
+# Need Python2 for Qubes
 python2
-sudo
-wget
-zsh
+
+# Basic utils
 ethtool
 net-tools
+sudo
+wget
+
+# User env
+zsh

--- a/update-local-repo.sh
+++ b/update-local-repo.sh
@@ -34,8 +34,8 @@ env $CHROOT_ENV chroot "$CHROOT_DIR" /bin/sh -c \
 
 # Update archlinux keyring first so that Archlinux can be updated even after a long time
 env $CHROOT_ENV chroot "$CHROOT_DIR" /bin/sh -c \
-    'pacman -Sy --noconfirm archlinux-keyring'
+    "http_proxy='${REPO_PROXY}' pacman -Sy --noconfirm archlinux-keyring"
 
 # Now update system
 env $CHROOT_ENV chroot "$CHROOT_DIR" /bin/sh -c \
-    'pacman -Syu --noconfirm'
+    "http_proxy='${REPO_PROXY}' pacman -Syu --noconfirm"


### PR DESCRIPTION
Fixes a new instance of the CheckSpace issue (where Arch tries to examine the "mount" at `/` only to find that there is none, being a chroot and all, then error out).  Also convinces makepkg to honor the http{,s}_proxy env var.  And finally tidies up the packages{,_minimal}.list lists to make them a bit clearer.
