### PR TITLE
Updating archlinux builder to 3.1

### DIFF
--- a/scripts/02_install_groups.sh
+++ b/scripts/02_install_groups.sh
@@ -22,6 +22,9 @@ PKGGROUPS="$(sed '/^ *#/d; s/  *#.*//' "${PKGLISTFILE}" | sed ':a;N;$!ba; s/\n/ 
 PACMAN_CACHE_DIR="${CACHEDIR}/pacman_cache"
 export PACMAN_CACHE_DIR
 
+echo "  --> Synchronize resolv.conf..."
+cp /etc/resolv.conf "${INSTALLDIR}/etc/resolv.conf"
+
 echo "  --> Installing archlinux package groups..."
 echo "    --> Selected packages: ${PKGGROUPS}"
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \

--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -72,8 +72,8 @@ ln -s ../usr/lib/os-release "${INSTALLDIR}/etc/os-release"
 sed '/QubesTMP/d' -i "${INSTALLDIR}/etc/pacman.conf"
 
 # Reregistering qubes repository to the remote version
-echo "  --> Registering Qubes remote repository..."
-cat >> "${INSTALLDIR}/etc/pacman.conf" <<EOF
-[qubes]
-Server = http://olivier.medoc.free.fr/archlinux/pkgs/
-EOF
+#echo "  --> Registering Qubes remote repository..."
+#cat >> "${INSTALLDIR}/etc/pacman.conf" <<EOF
+#[qubes]
+#Server = http://olivier.medoc.free.fr/archlinux/r3/
+#EOF

--- a/scripts/09_cleanup.sh
+++ b/scripts/09_cleanup.sh
@@ -31,3 +31,6 @@ umount "${INSTALLDIR}/var/cache/pacman" || true
 unset PACMAN_CACHE_DIR
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
     "pacman --noconfirm -Scc"
+
+echo " --> Cleaning /etc/resolv.conf"
+rm -f /etc/resolv.conf

--- a/scripts/arch-chroot-lite
+++ b/scripts/arch-chroot-lite
@@ -52,7 +52,6 @@ chroot_teardown() {
     unset CHROOT_ACTIVE_MOUNTS
 }
 
-
 usage() {
     cat <<EOF
 usage: ${0##*/} chroot-dir [command]
@@ -76,7 +75,7 @@ shift
 [[ -d $chrootdir ]] || die "Can't create chroot on non-directory %s" "$chrootdir"
 
 chroot_setup "$chrootdir" || die "failed to setup chroot %s" "$chrootdir"
-# arch-schroot-lite already has /etc/resolv.conf managed by the builder
+# arch-chroot-lite already has /etc/resolv.conf managed by the builder
 # scripts, so no need to bind to the host system's resolv.conf here
 
 SHELL=/bin/sh unshare --fork --pid chroot "$chrootdir" "$@"

--- a/scripts/packages.list
+++ b/scripts/packages.list
@@ -2,8 +2,9 @@
 xorg
 xterm
 
-# Need Python2 for Qubes
+# Need Python for Qubes
 python2
+python3
 
 # Basic utils
 ethtool


### PR DESCRIPTION
- `resolv.conf` now gets removed in 09_cleanup.sh.
- Currently I don't know a better solution than copying `resolv.conf` temporarily. So I do it the same way in `02_install_groups.sh` as it's done in `04_install_qubes.sh`.
