### PR TITLE
Add metapacakge base-devel to the builder chroot.

### DIFF
--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -49,7 +49,7 @@ if ! [ -d "${INSTALLDIR}/home/user" ]; then
     sed 's/^ *CheckSpace/#CheckSpace/g' -i "${INSTALLDIR}/etc/pacman.conf"
 
     echo "  --> Installing required makepkg dependencies..."
-    pkgs="binutils fakeroot sudo"
+    pkgs="base-devel binutils fakeroot sudo"
     "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
         "http_proxy='${REPO_PROXY}' pacman -Sy --needed --noconfirm --asdeps $pkgs"
 


### PR DESCRIPTION
This is needed to pull in autoconf and automake, which are required for
building the VM packages.  I've not investigated why this has become
necessary (the build used to work), but presumably they used to be
installed by default or pulled in as dependencies, but are no longer.
