### PR TITLE
preconfigure Qubes Proxy Service for pacman

### DIFF
--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -71,6 +71,10 @@ ln -s ../usr/lib/os-release "${INSTALLDIR}/etc/os-release"
 # Disable qubes local repository
 sed '/QubesTMP/d' -i "${INSTALLDIR}/etc/pacman.conf"
 
+# Enable Qubes Proxy in template
+PACMAN_PROXY='# Enable usage of Qubes Proxy Service\nXferCommand = echo "$(basename -s .part %o)" \&\& http_proxy=10.137.255.254:8082 /usr/bin/curl --progress-bar -C - -f %u -o %o'
+sed "s+^#XferCommand.*curl.*$+&\n${PACMAN_PROXY}+" -i "${INSTALLDIR}/etc/pacman.conf"
+
 # Reregistering qubes repository to the remote version
 #echo "  --> Registering Qubes remote repository..."
 #cat >> "${INSTALLDIR}/etc/pacman.conf" <<EOF


### PR DESCRIPTION
This makes pacman use Qubes Proxy for updates/installs. I'm pretty sure some time ago(1 year or so), this has been set already, but it's no longer(neither it's mentioned in git log).
It will also allow to remove powerpill install instructions(post tempalate creation) from documentation of archlinux template building making it more straightforward.