### PR TITLE
Allow https pacman mirrors

### DIFF
--- a/Makefile.archlinux
+++ b/Makefile.archlinux
@@ -18,7 +18,7 @@ DIST_BUILD_DIR = /home/user
 ### Local variables
 RUN_AS_USER = user
 
-PACMAN_MIRROR ?= mirror.rackspace.com
+PACMAN_MIRROR ?= http://mirror.rackspace.com
 
 
 DEBUG ?= 0

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -8,7 +8,7 @@ INSTALLDIR="$1"
 DISTRO="$2"  # aka elsewhere as $DIST
 
 BOOTSTRAP_DIR="${CACHEDIR}/bootstrap"
-PACMAN_MIRROR="${PACMAN_MIRROR:-mirror.rackspace.com}"
+PACMAN_MIRROR="${PACMAN_MIRROR:-http://mirror.rackspace.com}"
 
 PACMAN_CACHE_DIR="${CACHEDIR}/pacman_cache"
 export PACMAN_CACHE_DIR
@@ -33,7 +33,7 @@ mount --bind "$INSTALLDIR" "${BOOTSTRAP_DIR}/mnt"
 
 # TODO: This doesn't seem super elegant
 echo "  --> Setting pacman mirror as '$PACMAN_MIRROR'..."
-sed "s|#Server = http://${PACMAN_MIRROR}/|Server = http://${PACMAN_MIRROR}/|" \
+sed "s|#Server = ${PACMAN_MIRROR}/|Server = ${PACMAN_MIRROR}/|" \
     < "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist.dist" \
     > "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist"
 cp /etc/resolv.conf "${BOOTSTRAP_DIR}/etc/"


### PR DESCRIPTION
There are quite a lot of [https mirrors](https://www.archlinux.org/mirrorlist/all/https/) for pacman and the current version of the builder does not allow using one via the `PACMAN_MIRROR` environmental variable.