### PR TITLE
Replace ttf-symbola with noto-fonts-emoji

### DIFF
--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -64,12 +64,13 @@ cat >> "${INSTALLDIR}/etc/fstab" <<EOF
 #
 
 # Templates Directories
-/dev/mapper/dmroot /                       ext4 defaults,noatime        1 1
+/dev/mapper/dmroot /                       ext4 defaults,discard,noatime        1 1
 /dev/xvdb		/rw			auto	noauto,defaults,discard	1 2
 /dev/xvdc1      swap                    swap    defaults        0 0
 
 # Template Binds
 /rw/home        /home       none    noauto,bind,defaults 0 0
+/rw/usrlocal    /usr/local  none    noauto,bind,defaults 0 0
 
 # Template Customizations
 tmpfs                   /dev/shm                tmpfs   defaults,size=1G        0 0

--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -23,9 +23,9 @@ chown -R --reference="$PACMAN_CUSTOM_REPO_DIR" "$PACMAN_CUSTOM_REPO_DIR"
 
 echo "  --> Registering Qubes custom repository..."
 cat >> "${INSTALLDIR}/etc/pacman.conf" <<EOF
-[qubes] # QubesTMP
-SigLevel = Optional TrustAll # QubesTMP
-Server = file:///tmp/qubes-packages-mirror-repo/pkgs  # QubesTMP
+[qubes]
+SigLevel = Optional TrustAll
+Server = file:///tmp/qubes-packages-mirror-repo/pkgs
 EOF
 
 echo "  --> Synchronize resolv.conf..."
@@ -92,4 +92,4 @@ mkdir -p "${INSTALLDIR}/lib/modules"
 touch "${INSTALLDIR}/lib/modules/QUBES_NODELETE"
 
 # Disable qubes local repository
-sed '/QubesTMP/d' -i "${INSTALLDIR}/etc/pacman.conf"
+sed '/\[qubes]/,+2 d' -i "${INSTALLDIR}/etc/pacman.conf"

--- a/scripts/packages.list
+++ b/scripts/packages.list
@@ -22,7 +22,7 @@ ttf-inconsolata
 ttf-linux-libertine
 # Particularly good Unicode coverage:
 noto-fonts
-ttf-symbola
+noto-fonts-emoji
 
 # Gnome
 gnome-settings-daemon


### PR DESCRIPTION
Fix template build failing because ttf-symbola has been removed from the
archlinux repositories in favor of noto-fonts-emoji.