### PR TITLE
Fix for 00_prepare.sh

### DIFF
--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -4,7 +4,7 @@ echo "--> Archlinux 00_prepare.sh"
 
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
 ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-http://mirrors.kernel.org/archlinux}"
-BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha1sums.txt | grep bootstrap | awk '{print $2}')
+BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha1sums.txt | grep -o "archlinux-bootstrap-[0-9.]*-x86_64.tar.gz")
 
 BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
 GPG_ENV="GNUPGHOME=${CACHEDIR}/gpghome"

--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -1,12 +1,10 @@
-#!/bin/bash -e
-# vim: set ts=4 sw=4 sts=4 et :
-### 00_prepare.sh : Download and extract the archlinux bootstrap mini-distro
+#! /bin/bash
+
 echo "--> Archlinux 00_prepare.sh"
 
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
-
 ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-http://mirrors.kernel.org/archlinux}"
-BOOTSTRAP_TARBALL=$(wget -qO- $ARCHLINUX_SRC_PREFIX/iso/latest/sha1sums.txt | grep bootstrap | awk '{print $2}')
+BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha1sums.txt | grep bootstrap | awk '{print $2}')
 
 BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
 GPG_ENV="GNUPGHOME=${CACHEDIR}/gpghome"
@@ -23,10 +21,10 @@ http_proxy="$REPO_PROXY" wget -N -P "$CACHEDIR" "${BOOTSTRAP_URL}.sig"
 echo "  --> Preparing GnuPG to verify tarball..."
 mkdir -p "${CACHEDIR}/gpghome"
 chmod -R go-rwx "${CACHEDIR}/gpghome"
-env $GPG_ENV gpg --import "${ARCHLINUX_PLUGIN_DIR}/keys/archlinux-master-keys.asc" || exit
+env "$GPG_ENV" gpg --import "${ARCHLINUX_PLUGIN_DIR}/keys/archlinux-master-keys.asc" || exit
 
 echo "  --> Verifying tarball..."
-env $GPG_ENV gpg --verify "${CACHEDIR}/${BOOTSTRAP_TARBALL}.sig" "${CACHEDIR}/${BOOTSTRAP_TARBALL}" || exit
+env "$GPG_ENV" gpg --verify "${CACHEDIR}/${BOOTSTRAP_TARBALL}.sig" "${CACHEDIR}/${BOOTSTRAP_TARBALL}" || exit
 
 if [ "${CACHEDIR}/${BOOTSTRAP_TARBALL}" -nt "${CACHEDIR}/bootstrap/.extracted" ]; then
     echo "  --> Extracting bootstrap tarball (nuking previous directory)..."

--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -6,10 +6,9 @@ echo "--> Archlinux 00_prepare.sh"
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
 
 ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-http://mirrors.kernel.org/archlinux}"
-ARCHLINUX_REL_VERSION="${ARCHLINUX_REL_VERSION:-$(date --date=yesterday '+%Y.%m').01}"
-BOOTSTRAP_TARBALL="archlinux-bootstrap-${ARCHLINUX_REL_VERSION}-x86_64.tar.gz"
+BOOTSTRAP_TARBALL=$(wget -qO- $ARCHLINUX_SRC_PREFIX/iso/latest/sha1sums.txt | grep bootstrap | awk '{print $2}')
 
-BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/${ARCHLINUX_REL_VERSION}/${BOOTSTRAP_TARBALL}"
+BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
 GPG_ENV="GNUPGHOME=${CACHEDIR}/gpghome"
 
 [ "$VERBOSE" -ge 2 -o "$DEBUG" -gt 0 ] && set -x


### PR DESCRIPTION
Corrections were needed to the **00_prepare.sh** script, as they referenced incorrect filenames.