### PR TITLE
Remote ttf-freefont from packages

### DIFF
--- a/scripts/packages.list
+++ b/scripts/packages.list
@@ -17,7 +17,6 @@ vim
 terminus-font
 font-bitstream-speedo
 ttf-dejavu
-ttf-freefont
 ttf-inconsolata
 ttf-linux-libertine
 # Particularly good Unicode coverage:


### PR DESCRIPTION
ttf-freefont doesn't exist anymore in archlinux. 
If someone what the freefont fonts, it could be replaced by ``gnu-free-fonts`` , but this is not ttf fonts.