### PR TITLE
fix `error: target not found: linux`

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -48,9 +48,6 @@ export PACMAN_CACHE_MOUNT_DIR="${BOOTSTRAP_DIR}/mnt/var/cache/pacman"
     "http_proxy='${REPO_PROXY}' pacstrap /mnt base"
 unset PACMAN_CACHE_MOUNT_DIR
 
-echo "  --> Removing non-required linux kernel (can be added manually through a package)..."
-"${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/pacman --noconfirm -Rsc linux
-
 echo "  --> Unbinding INSTALLDIR..."
 umount ${BOOTSTRAP_DIR}/mnt
 


### PR DESCRIPTION
```
Be aware that base as it stands does not currently contain:
- A kernel
- An editor
```
https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/