### PR TITLE
The binary cmp was missing. The package diffutils provide it. It was …

### DIFF
--- a/scripts/packages.list
+++ b/scripts/packages.list
@@ -7,6 +7,7 @@ ethtool
 net-tools
 sudo
 wget
+diffutils
 
 # User env
 ldns

--- a/scripts/packages_minimal.list
+++ b/scripts/packages_minimal.list
@@ -7,3 +7,4 @@ ethtool
 net-tools
 sudo
 wget
+diffutils


### PR DESCRIPTION
…probably included as a dependency from obsolete package (maybe from xf86dgaproto that was removed few days ago, but idk how to find the original PKGBUILD since the package was deleted). https://old.reddit.com/r/Qubes/comments/eg50ne/built_arch_linux_template_and_installed_but_app/
( Does someone have a better idea on why the binary cmp disappeared ? )