### PR TITLE
changed every copied package from local from .pkg.tar.xz to .pkg.tar.zst

### DIFF
--- a/Makefile.archlinux
+++ b/Makefile.archlinux
@@ -83,7 +83,7 @@ dist-prepare-chroot: $(CHROOT_DIR)/home/user/.prepared_base
 	@sudo mkdir -p "$(CACHEDIR)/pacman_cache/pkg"
 	@sudo touch "$(CACHEDIR)/pacman_cache/pkg/.mnt"
 	@# qubes pkgs may be from old runs and no longer match the repo hashes
-	@sudo rm "$(CACHEDIR)/pacman_cache/pkg"/qubes-*.pkg.tar.xz 2>/dev/null || true
+	@sudo rm "$(CACHEDIR)/pacman_cache/pkg"/qubes-*.pkg.tar.* 2>/dev/null || true
 	@if ! [ -r "$(CHROOT_DIR)/var/cache/pacman/pkg/.mnt" ]; then\
 		echo "    --> sudo mount --bind "$(CACHEDIR)/pacman_cache" "$(CHROOT_DIR)/var/cache/pacman";"; \
 		mkdir -p "$(CHROOT_DIR)/var/cache/pacman";\
@@ -133,13 +133,13 @@ dist-copy-out:
 	for arch_chroot_dir in $(CHROOT_DIR)/$(DIST_SRC)/; do\
 		arch_pkg_dir=$(ORIG_SRC)/pkgs;\
 		mkdir -p $$arch_pkg_dir;\
-		for pkg in $$arch_chroot_dir/*.pkg.tar.xz; do\
+		for pkg in $$arch_chroot_dir/*.pkg.tar.*; do\
 			echo "      $$arch_pkg_dir/`basename $$pkg`" >&3 ;\
 		done;\
 		mkdir -p $(BUILDER_REPO_DIR)/pkgs;\
-		ln -f -t $(BUILDER_REPO_DIR)/pkgs $$arch_chroot_dir/*.pkg.tar.xz;\
+		ln -f -t $(BUILDER_REPO_DIR)/pkgs $$arch_chroot_dir/*.pkg.tar.*;\
 	done;\
-	mv -t $$arch_pkg_dir $$arch_chroot_dir/*.pkg.tar.xz
+	mv -t $$arch_pkg_dir $$arch_chroot_dir/*.pkg.tar.*
 
 ### Additional targets
 
@@ -153,13 +153,13 @@ endif
 	for arch_build_dir in $(ARCH_BUILD_DIRS); do\
 	  pkgnames=`cat $(ORIG_SRC)/$$arch_build_dir/PKGBUILD | grep pkgname | cut -d "=" -f 2 | tr -d '()"'`;\
 	  for pkgname in $$pkgnames; do\
-	    ln -f $(ORIG_SRC)/pkgs/$$pkgname-*.pkg.tar.xz $(UPDATE_REPO)/pkgs/;\
+	    ln -f $(ORIG_SRC)/pkgs/$$pkgname-*.pkg.tar.* $(UPDATE_REPO)/pkgs/;\
 	  done;\
 	done;\
 
 # Sign packages
 sign:
 	cd $(ORIG_SRC)
-	for filename in pkgs/*.pkg.tar.xz ; do
+	for filename in pkgs/*.pkg.tar.* ; do
 	  qubes-gpg-client-wrapper --detatch-sign "$filename" > "$filename.sig"
 	done

--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -18,7 +18,7 @@ su -c "echo 'Include = /etc/pacman.d/mirrorlist' >> $INSTALLDIR/etc/pacman.conf"
 echo "  --> Updating Qubes custom repository..."
 # Repo Add need packages to be added in the right version number order as it only keeps the last entered package version
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
-    'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/*.pkg.tar.xz`; do repo-add pkgs/qubes.db.tar.gz "$pkg"; done;'
+    'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/*.pkg.tar.*`; do repo-add pkgs/qubes.db.tar.gz "$pkg"; done;'
 chown -R --reference="$PACMAN_CUSTOM_REPO_DIR" "$PACMAN_CUSTOM_REPO_DIR"
 
 echo "  --> Registering Qubes custom repository..."
@@ -53,7 +53,7 @@ echo "  --> Installing qubes apps"
 
 echo "  --> Copying binary repository keyring package"
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
-    "cp /tmp/qubes-packages-mirror-repo/pkgs/qubes-vm-keyring*.pkg.tar.xz /etc/pacman.d/"
+    "cp /tmp/qubes-packages-mirror-repo/pkgs/qubes-vm-keyring*.pkg.tar.* /etc/pacman.d/"
 
 echo "  --> Updating template fstab file..."
 cat >> "${INSTALLDIR}/etc/fstab" <<EOF

--- a/scripts/arch-chroot-lite
+++ b/scripts/arch-chroot-lite
@@ -35,7 +35,7 @@ chroot_setup() {
         PACMAN_CACHE_MOUNT_DIR="${PACMAN_CACHE_MOUNT_DIR:-$1/var/cache/pacman}"
         mkdir -p "$PACMAN_CACHE_MOUNT_DIR"
         # Cached qubes packages may be from old runs and throw checksum errors
-        rm "$PACMAN_CACHE_DIR/pkg"/qubes-*.pkg.tar.xz 2>/dev/null || true
+        rm "$PACMAN_CACHE_DIR/pkg"/qubes-*.pkg.tar.* 2>/dev/null || true
         chroot_add_mount "$PACMAN_CACHE_DIR" "$PACMAN_CACHE_MOUNT_DIR" --bind
     fi
     if [[ -d "$PACMAN_CUSTOM_REPO_DIR" ]]; then

--- a/update-local-repo.sh
+++ b/update-local-repo.sh
@@ -12,10 +12,10 @@ mkdir -p "$PKGS_DIR"
 if [ ! -f "${PKGS_DIR}/qubes.db" ]; then
     # pacman does not deal correctly with empty repositories
     echo "  -> Repo '${PKGS_DIR}' appears empty; initialising with pacman itself..."
-    cp "${CHROOT_DIR}/var/cache/pacman/pkg"/pacman*.pkg.tar.xz "${PKGS_DIR}/"
-    cp "${CHROOT_DIR}/var/cache/pacman/pkg"/sudo*.pkg.tar.xz "${PKGS_DIR}/"
-    cp "${CACHEDIR}/pacman_cache/pkg"/pacman*.pkg.tar.xz "${PKGS_DIR}/"
-    cp "${CACHEDIR}/pacman_cache/pkg"/sudo*.pkg.tar.xz "${PKGS_DIR}/"
+    cp "${CHROOT_DIR}/var/cache/pacman/pkg"/pacman*.pkg.tar.* "${PKGS_DIR}/"
+    cp "${CHROOT_DIR}/var/cache/pacman/pkg"/sudo*.pkg.tar.* "${PKGS_DIR}/"
+    cp "${CACHEDIR}/pacman_cache/pkg"/pacman*.pkg.tar.* "${PKGS_DIR}/"
+    cp "${CACHEDIR}/pacman_cache/pkg"/sudo*.pkg.tar.* "${PKGS_DIR}/"
 
 fi
 
@@ -29,7 +29,7 @@ env $CHROOT_ENV chroot "$CHROOT_DIR" /bin/su user -c \
 # Generate custom repository metadata based on packages that are available
 # Repo Add need packages to be added in the right version number order as it only keeps the last entered package version
 env $CHROOT_ENV chroot "$CHROOT_DIR" /bin/su user -c \
-    'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/*.pkg.tar.xz`; do repo-add pkgs/qubes.db.tar.gz "$pkg"; done;'
+    'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/*.pkg.tar.*`; do repo-add pkgs/qubes.db.tar.gz "$pkg"; done;'
 
 # Ensure pacman doesn't check for disk free space -- it doesn't work in chroots
 env $CHROOT_ENV chroot "$CHROOT_DIR" /bin/sh -c \

--- a/update-remote-repo.sh
+++ b/update-remote-repo.sh
@@ -7,7 +7,7 @@ db=qubes.db
 
 echo "Signing all unsigned packages"
 
-for filename in $package_directory/*.pkg.tar.xz ; do
+for filename in $package_directory/*.pkg.tar.* ; do
 	if ! [ -f "$filename.sig" ] ; then
 		echo "Signing $filename"
 		qubes-gpg-client-wrapper --detach-sign "$filename" > "$filename.sig"
@@ -17,7 +17,7 @@ done
 sudo mount --bind $archlinux_directory chroot-$name/tmp/qubes-packages-mirror-repo
 
 echo "Generating 4.0 repository"
-sudo chroot chroot-$name su user -c 'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/qubes*.pkg.tar.xz` ; do repo-add pkgs/'"$db"'.tar.gz "$pkg";done;'
+sudo chroot chroot-$name su user -c 'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/qubes*.pkg.tar.*` ; do repo-add pkgs/'"$db"'.tar.gz "$pkg";done;'
 
 # Replace link with the real thing because it cannot be uploaded easily to repository
 rm $package_directory/$db


### PR DESCRIPTION
Starting with devtools 20191227 the Arch repos use the zstandard compression instead of xz compression (see https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/). This change reflects the new filenames *.pkg.tar.zst instead of .pkg.tar.xz by changing every mention of *.pkg.tar.xz to *.pkg.tar.*. This is possible since
a) we don't know whether the maintainer of pacman and sudo actually updated devtools to >= 20191227.
b) there are no other files than .pkg.tar.xz and .pkg.tar.zst (sig files are in some other location).
Refer also to QubesOS/qubes-issues#5769 .

This is a second pr with actual signed commits because I couldn't get the other one to work (the old one being #32).