### PR TITLE
Mount pacman private-keys-v1 as tmpfs

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -50,8 +50,8 @@ sed "s|#Server = ${PACMAN_MIRROR}/|Server = ${PACMAN_MIRROR}/|" \
 cp /etc/resolv.conf "${BOOTSTRAP_DIR}/etc/"
 
 echo "  --> Initializing pacman keychain..."
-"${SCRIPTSDIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/pacman-key --init
-"${SCRIPTSDIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/pacman-key --populate
+"${SCRIPTSDIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/sh -c \
+    "pacman-key --init && pacman-key --populate"
 
 echo "  --> Installing core pacman packages..."
 export PACMAN_CACHE_MOUNT_DIR="${BOOTSTRAP_DIR}/mnt/var/cache/pacman"

--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -72,7 +72,7 @@ cat >> "${INSTALLDIR}/etc/fstab" <<EOF
 
 # Template Customizations
 tmpfs                   /dev/shm                                    tmpfs   defaults,size=1G            0 0
-tmpfs                   /etc/pacman.d/gnupg/private-keys-v1.d       tmpfs   defaults,noexec,mode=600    0 0
+tmpfs                   /etc/pacman.d/gnupg/private-keys-v1.d       tmpfs   defaults,noexec,nosuid,nodev,mode=600    0 0
 
 EOF
 

--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -71,7 +71,8 @@ cat >> "${INSTALLDIR}/etc/fstab" <<EOF
 /rw/usrlocal    /usr/local  none    noauto,bind,defaults 0 0
 
 # Template Customizations
-tmpfs                   /dev/shm                tmpfs   defaults,size=1G        0 0
+tmpfs                   /dev/shm                                    tmpfs   defaults,size=1G            0 0
+tmpfs                   /etc/pacman.d/gnupg/private-keys-v1.d       tmpfs   defaults,noexec,mode=600    0 0
 
 EOF
 

--- a/scripts/arch-chroot-lite
+++ b/scripts/arch-chroot-lite
@@ -31,7 +31,8 @@ chroot_setup() {
     chroot_add_mount shm "$1/dev/shm" -t tmpfs -o mode=1777,nosuid,nodev &&
     chroot_add_mount run "$1/run" -t tmpfs -o nosuid,nodev,mode=0755 &&
     chroot_add_mount tmp "$1/tmp" -t tmpfs -o mode=1777,strictatime,nodev,nosuid &&
-    chroot_add_mount pacman-privkeys "$1/etc/pacman.d/gnupg/private-keys-v1.d" -t tmpfs -o mode=600,nosuid,noexec
+    chroot_add_mount pacman-privkeys "$1/etc/pacman.d/gnupg/private-keys-v1.d" -t tmpfs -o mode=600,nosuid,noexec,nodev ||
+    exit
     if [[ -d "$PACMAN_CACHE_DIR" ]]; then
         PACMAN_CACHE_MOUNT_DIR="${PACMAN_CACHE_MOUNT_DIR:-$1/var/cache/pacman}"
         mkdir -p "$PACMAN_CACHE_MOUNT_DIR"

--- a/scripts/arch-chroot-lite
+++ b/scripts/arch-chroot-lite
@@ -30,7 +30,8 @@ chroot_setup() {
     chroot_add_mount devpts "$1/dev/pts" -t devpts -o mode=0620,gid=5,nosuid,noexec &&
     chroot_add_mount shm "$1/dev/shm" -t tmpfs -o mode=1777,nosuid,nodev &&
     chroot_add_mount run "$1/run" -t tmpfs -o nosuid,nodev,mode=0755 &&
-    chroot_add_mount tmp "$1/tmp" -t tmpfs -o mode=1777,strictatime,nodev,nosuid
+    chroot_add_mount tmp "$1/tmp" -t tmpfs -o mode=1777,strictatime,nodev,nosuid &&
+    chroot_add_mount pacman-privkeys "$1/etc/pacman.d/gnupg/private-keys-v1.d" -t tmpfs -o mode=600,nosuid,noexec
     if [[ -d "$PACMAN_CACHE_DIR" ]]; then
         PACMAN_CACHE_MOUNT_DIR="${PACMAN_CACHE_MOUNT_DIR:-$1/var/cache/pacman}"
         mkdir -p "$PACMAN_CACHE_MOUNT_DIR"


### PR DESCRIPTION
Fixes: https://github.com/QubesOS/qubes-issues/issues/6242

As mentioned by @DemiMarie on, this should prevent a compromised AppVM to sign packages that the TemplateVM will trust (by mounting that folder as tmpfs on both builder and template).