### PR TITLE
Increase default pacman mirrors

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -8,7 +8,14 @@ INSTALLDIR="$1"
 DISTRO="$2"  # aka elsewhere as $DIST
 
 BOOTSTRAP_DIR="${CACHEDIR}/bootstrap"
-PACMAN_MIRROR="${PACMAN_MIRROR:-http://mirror.rackspace.com}"
+DEFAULT_PACMAN_MIRRORS="\
+http://mirror.rackspace.com\
+,http://mirrors.evowise.com\
+,https://mirror.rackspace.com\
+"
+PACMAN_MIRRORS="${PACMAN_MIRRORS:-$DEFAULT_PACMAN_MIRRORS}"
+IFS="," read -r -a PACMAN_MIRRORS \
+  <<< $PACMAN_MIRRORS
 
 PACMAN_CACHE_DIR="${CACHEDIR}/pacman_cache"
 export PACMAN_CACHE_DIR
@@ -43,10 +50,13 @@ echo "  --> Binding INSTALLDIR '${INSTALLDIR}' to bootstrap environment..."
 mount --bind "$INSTALLDIR" "${BOOTSTRAP_DIR}/mnt"
 
 # TODO: This doesn't seem super elegant
-echo "  --> Setting pacman mirror as '$PACMAN_MIRROR'..."
-sed "s|#Server = ${PACMAN_MIRROR}/|Server = ${PACMAN_MIRROR}/|" \
-    < "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist.dist" \
-    > "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist"
+echo "  --> Setting pacman mirrorlist as '${PACMAN_MIRRORS[@]}'..."
+PACMAN_MIRRORLIST=$(cat ${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist.dist)
+for PACMAN_MIRROR in "${PACMAN_MIRRORS[@]}"
+do
+  PACMAN_MIRRORLIST=$(sed "s|#Server = ${PACMAN_MIRROR}/|Server = ${PACMAN_MIRROR}/|" <<< $PACMAN_MIRRORLIST)
+done
+echo "$PACMAN_MIRRORLIST" > "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist"
 cp /etc/resolv.conf "${BOOTSTRAP_DIR}/etc/"
 
 echo "  --> Initializing pacman keychain..."


### PR DESCRIPTION
Using a single mirror caused builds to fail in some circumstances, where ```http://mirror.rackspace.com``` couldn't be reached, so increasing the default mirrors should mitigate the issue. Also, updated the script to allow passing multiple mirrors separated by a comma.