### PR TITLE
Adjust arch-chroot-lite

### DIFF
--- a/scripts/arch-chroot-lite
+++ b/scripts/arch-chroot-lite
@@ -29,7 +29,7 @@ chroot_setup() {
 
     # private-keys-v1.d does not exist before we create the tmpfs
     mkdir -p -m 0755 -- "${secret_key_dir%/*}" &&
-    mkdir -m 0000 -- "$secret_key_dir" &&
+    mkdir -p -m 0000 -- "$secret_key_dir" &&
 
     # Set the correct permissions for mount points
     chmod -- 0755 "$1/dev" "$1/run" &&
@@ -37,7 +37,7 @@ chroot_setup() {
     chmod -- 1777 "$1/tmp" &&
 
     # Create README
-    cat > "$secret_key_dir/README" <<'EOF' &&
+    [[ -f "$secret_key_dir/README" ]] || cat > "$secret_key_dir/README" <<'EOF' &&
 # Why is this directory immutable?
 
 In QubesOS, a TemplateVM’s root volume is readable by all AppVMs based on it.


### PR DESCRIPTION
When running ```make qubes-vm```, users will get this error:

```
  --> Installing core pacman packages...
mkdir: cannot create directory ‘/home/user/qubes-builder/cache/archlinux/bootstrap/etc/pacman.d/gnupg/private-keys-v1.d’: File exists
umount: bad usage
Try 'umount --help' for more information.
  --> Unbinding INSTALLDIR...
make[1]: *** [/home/user/qubes-builder/qubes-src/builder-archlinux/Makefile.archlinux:117: /home/user/qubes-builder/chroot-vm-archlinux/home/user/.prepared_base] Error 1
make: *** [Makefile:254: vmm-xen-vm] Error 1
```

A similar error will be thrown when creating ```/etc/pacman.d/gnupg/private-keys-v1.d/README```