### PR TITLE
Fix Arch build

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -66,7 +66,7 @@ echo "  --> Initializing pacman keychain..."
 echo "  --> Installing core pacman packages..."
 export PACMAN_CACHE_MOUNT_DIR="${BOOTSTRAP_DIR}/mnt/var/cache/pacman"
 "${SCRIPTSDIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/sh -c \
-    "http_proxy='${REPO_PROXY}' pacstrap /mnt base"
+    "until ALL_PROXY='${REPO_PROXY}' pacstrap /mnt base; do sleep 0.1; done"
 unset PACMAN_CACHE_MOUNT_DIR
 
 touch "${INSTALLDIR}/.prepared_base"

--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -1,9 +1,13 @@
-#! /bin/bash
+#! /bin/bash --
 
+set -euo pipefail
 echo "--> Archlinux 00_prepare.sh"
 
+if [[ -n "${REPO_PROXY+x}" ]]; then
+    export "https_proxy=$REPO_PROXY" "http_proxy=$REPO_PROXY"
+fi
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
-ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-http://mirrors.kernel.org/archlinux}"
+ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-https://mirrors.edge.kernel.org/archlinux}"
 BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha1sums.txt | grep -o "archlinux-bootstrap-[0-9.]*-x86_64.tar.gz")
 
 BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
@@ -12,10 +16,10 @@ BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
 
 mkdir -p "${CACHEDIR}/pacman_cache"
 
-echo "  --> Downloading Archlinux bootstrap tarball (v${ARCHLINUX_REL_VERSION})..."
+echo "  --> Downloading Archlinux bootstrap tarball (v${ARCHLINUX_REL_VERSION-})..."
 
-http_proxy="$REPO_PROXY" wget -N -P "$CACHEDIR" "$BOOTSTRAP_URL"
-http_proxy="$REPO_PROXY" wget -N -P "$CACHEDIR" "${BOOTSTRAP_URL}.sig"
+wget -N -P "$CACHEDIR" "$BOOTSTRAP_URL"
+wget -N -P "$CACHEDIR" "${BOOTSTRAP_URL}.sig"
 
 echo "  --> Preparing GnuPG to verify tarball..."
 mkdir -p "${CACHEDIR}/gpghome"
@@ -31,7 +35,7 @@ if [ "${CACHEDIR}/${BOOTSTRAP_TARBALL}" -nt "${CACHEDIR}/bootstrap/.extracted" ]
     rm -rf "${CACHEDIR}/bootstrap/"
     mkdir -p "${CACHEDIR}/bootstrap"
     # By default will extract to a "root.x86_64" directory; strip that off
-    tar xzC "${CACHEDIR}/bootstrap" --strip-components=1 -f "${CACHEDIR}/${BOOTSTRAP_TARBALL}"
+    tar -xzC "${CACHEDIR}/bootstrap" --strip-components=1 -f "${CACHEDIR}/${BOOTSTRAP_TARBALL}"
     # Copy the distribution-provided version to be rewritten based on the
     # value of $ARCHLINUX_MIRROR each run (by the Makefile)
     cp -a "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist" "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist.dist"


### PR DESCRIPTION
- Add retry loops
- Switch to ‘mirrors.edge.kernel.org’ as the Pacman mirror, as it is
  a Tier 1 mirror and thus far more up-to-date.
- Use a ramfs for the Pacman master key