### PR TITLE
refactor: improve mirrorlist mechanism

### DIFF
--- a/Makefile.archlinux
+++ b/Makefile.archlinux
@@ -18,8 +18,6 @@ DIST_BUILD_DIR = /home/user
 ### Local variables
 RUN_AS_USER = user
 
-ARCHLINUX_MIRROR ?= http://mirror.rackspace.com
-
 
 DEBUG ?= 0
 ifneq ($(DEBUG),0)
@@ -56,7 +54,7 @@ ifneq ($(DEBUG),0)
   $(info ║ REPO_PROXY:            $(REPO_PROXY))             #
   $(info ║ ARCHLINUX_SRC_PREFIX:  $(ARCHLINUX_SRC_PREFIX))   # http://mirrors.kernel.org/archlinux
   $(info ║ ARCHLINUX_REL_VERSION: $(ARCHLINUX_REL_VERSION))  #
-  $(info ║ ARCHLINUX_MIRROR:      $(ARCHLINUX_MIRROR))       # mirror.rackspace.com
+  $(info ║ ARCHLINUX_MIRROR:      $(ARCHLINUX_MIRROR))       # default defined in prepare-chroot-base
   $(info ╚═══════════════════════════════════════════════════════════════════════════════)
 endif
 

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -5,17 +5,18 @@
 echo "--> Archlinux prepare-chroot-base"
 
 INSTALLDIR="$1"
-DISTRO="$2"  # aka elsewhere as $DIST
+DISTRO="$2" # aka elsewhere as $DIST
 
 BOOTSTRAP_DIR="${CACHEDIR}/bootstrap"
 DEFAULT_ARCHLINUX_MIRROR="\
-http://mirror.rackspace.com\
-,http://mirrors.evowise.com\
-,https://mirror.rackspace.com\
+https://mirror.rackspace.com/archlinux\
+,https://arch.mirror.constant.com\
+,https://mirror.f4st.host/archlinux\
+,https://mirrors.edge.kernel.org/archlinux\
 "
 ARCHLINUX_MIRROR="${ARCHLINUX_MIRROR:-$DEFAULT_ARCHLINUX_MIRROR}"
 IFS="," read -r -a ARCHLINUX_MIRROR \
-  <<< $ARCHLINUX_MIRROR
+    <<<$ARCHLINUX_MIRROR
 
 PACMAN_CACHE_DIR="${CACHEDIR}/pacman_cache"
 export PACMAN_CACHE_DIR
@@ -49,14 +50,11 @@ fi
 echo "  --> Binding INSTALLDIR '${INSTALLDIR}' to bootstrap environment..."
 mount --bind "$INSTALLDIR" "${BOOTSTRAP_DIR}/mnt"
 
-# TODO: This doesn't seem super elegant
-echo "  --> Setting pacman mirrorlist as '${ARCHLINUX_MIRROR[@]}'..."
-ARCHLINUX_MIRRORLIST=$(cat ${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist.dist)
-for MIRROR_ENTRY in "${ARCHLINUX_MIRROR[@]}"
-do
-  ARCHLINUX_MIRRORLIST=$(sed "s|#Server = ${MIRROR_ENTRY}/|Server = ${MIRROR_ENTRY}/|" <<< $ARCHLINUX_MIRRORLIST)
-done
-echo "$ARCHLINUX_MIRRORLIST" > "${CACHEDIR}/bootstrap/etc/pacman.d/mirrorlist"
+echo -e "  --> Setting pacman mirrorlist as:\n$(echo ${ARCHLINUX_MIRROR[@]} | tr ' ' '\n')\n"
+for MIRROR_ENTRY in "${ARCHLINUX_MIRROR[@]}"; do
+    echo "Server = $MIRROR_ENTRY/\$repo/os/\$arch"
+done >"${BOOTSTRAP_DIR}/etc/pacman.d/mirrorlist"
+
 cp /etc/resolv.conf "${BOOTSTRAP_DIR}/etc/"
 
 echo "  --> Initializing pacman keychain..."


### PR DESCRIPTION
This PR addresses 2 things:

- Set defaults in ```Makefile.archlinux``` only (previously, ```ARCHLINUX_MIRROR``` on ```Makefile.archlinux``` was replacing defaults set in ```prepare-chroot-base```)
- Use a file instead of mirror string envs separated by comma and sed'ing into mirrorlist.dist, this method is way more clean and direct, also it's more ergonomic for users in case they want to specify a long list of servers.