### PR TITLE
Make official Qubes repositories avaiable in Arch templates

### DIFF
--- a/scripts/01_install_core.sh
+++ b/scripts/01_install_core.sh
@@ -4,7 +4,6 @@
 echo "--> Archlinux 01_install_core.sh"
 
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
-
 set -e
 [ "$VERBOSE" -ge 2 -o "$DEBUG" -gt 0 ] && set -x
 
@@ -12,11 +11,11 @@ set -e
 # scripts/arch-chroot-lite for details
 unset SKIP_VOLATILE_SECRET_KEY_DIR
 
+"${ARCHLINUX_PLUGIN_DIR}/prepare-chroot-base" "$INSTALLDIR" "$DIST"
+
 # Now there is an official Qubes repository install the Qubes key
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" pacman-key --add - < \
     "${ARCHLINUX_PLUGIN_DIR}/keys/qubes-repo-archlinux-key.asc"
-key_fpr=$(gpg --with-colons --show-key "${ARCHLINUX_PLUGIN_DIR}/keys/qubes-repo-archlinux-key.asc"|\
+key_fpr=$(gpg --with-colons --show-key "${ARCHLINUX_PLUGIN_DIR}/keys/qubes-repo-archlinux-key.asc" |\
             grep ^fpr: | cut -d : -f 10)
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" pacman-key --lsign "$key_fpr"
-
-"${ARCHLINUX_PLUGIN_DIR}/prepare-chroot-base" "$INSTALLDIR" "$DIST"

--- a/scripts/01_install_core.sh
+++ b/scripts/01_install_core.sh
@@ -12,4 +12,11 @@ set -e
 # scripts/arch-chroot-lite for details
 unset SKIP_VOLATILE_SECRET_KEY_DIR
 
+# Now there is an official Qubes repository install the Qubes key
+"${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" pacman-key --add - < \
+    "${ARCHLINUX_PLUGIN_DIR}/keys/qubes-repo-archlinux-key.asc"
+key_fpr=$(gpg --with-colons --show-key "${ARCHLINUX_PLUGIN_DIR}/keys/qubes-repo-archlinux-key.asc"|\
+            grep ^fpr: | cut -d : -f 10)
+"${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" pacman-key --lsign "$key_fpr"
+
 "${ARCHLINUX_PLUGIN_DIR}/prepare-chroot-base" "$INSTALLDIR" "$DIST"

--- a/scripts/09_cleanup.sh
+++ b/scripts/09_cleanup.sh
@@ -32,6 +32,10 @@ unset PACMAN_CACHE_DIR
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
     "pacman --noconfirm -Scc"
 
+# Make Qubes repositories available
+mv "${INSTALLDIR}/etc/pacman.d/99-qubes-repository-4.0.conf.disabled" "${INSTALLDIR}/etc/pacman.d/99-qubes-repository-4.0.conf"
+sed -i s/^#Server/Server/ "${INSTALLDIR}/etc/pacman.d/99-qubes-repository-4.0.conf"
+
 echo " --> Cleaning /etc/resolv.conf"
 rm -f "${INSTALLDIR}/etc/resolv.conf"
 cat > "${INSTALLDIR}/etc/resolv.conf" << EOF


### PR DESCRIPTION
Addresses  QubesOS/qubes-issues#6610 by importing Qubes key followed by local sign.
Actual repository definition set in core-agent-linux