### PR TITLE
fix tarball bootstrap wget

### DIFF
--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -8,7 +8,7 @@ if [[ -n "${REPO_PROXY+x}" ]]; then
 fi
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
 ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-https://mirrors.edge.kernel.org/archlinux}"
-BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha1sums.txt | grep -o "archlinux-bootstrap-[0-9.]*-x86_64.tar.gz")
+BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha256sums.txt | grep -o "archlinux-bootstrap-[0-9.]*-x86_64.tar.gz")
 
 BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
 


### PR DESCRIPTION
When following the [Building the 'archlinux-minimal' Qubes template](https://github.com/Qubes-Community/Contents/blob/master/docs/building/building-archlinux-template.md) guide, in `Step 4` when running `make vmm-xen-vm` an error occured. 

<details>
  <summary>error</summary>

```
--> Archlinux preparing build chroot environment
--> Archlinux prepare-chroot-builder
  --> Installing archlinux build root:
--> Archlinux prepare-chroot-base
  --> Bootstrap chroot environment may not exist, calling 00_prepare.sh...
--> Archlinux 00_prepare.sh
  --> Unbinding INSTALLDIR...
umount: /home/user/qubes-builder/cache/archlinux/bootstrap/mnt: no mount point specified.
make[1]: *** [/home/user/qubes-builder/qubes-src/builder-archlinux/Makefile.archlinux:88: /home/user/qubes-builder/chroot-vm-archlinux/home/user/.prepared_base] Error 1
make: *** [Makefile:265: vmm-xen-vm] Error 1

```

</details>

This error was traced and it was discovered that in the `latest` / `2022.10.01` release of Archlinux, they do not include a `sha1sums.txt` in their release.

eg: 
- <https://mirrors.edge.kernel.org/archlinux/iso/latest/>
- <https://geo.mirror.pkgbuild.com/iso/latest/>
- <http://mirror.rackspace.com/archlinux/iso/latest/>

I was unable to find any documented reason for the absence of this file in this months release of Archlinux, and it could be a one time thing.

This PR fixes this by grepping the `sha256sums.txt` file instead.

Notes:

Setup script was used to configure `builder.conf`

<details>
  <summary><b>builder.conf</b></summary>

```
# =============================================================================
#                  CONFIGURATION FILE FOR QUBES-BUILDER
# =============================================================================
#
# THIS CONFIGURATION FILE IS INDENDED TO ONLY BE USED WITH THE `setup` SCRIPT.
# -----------------------------------------------------------------------------
#
# This configuration file (`templates.conf`) will be linked to by `setup` as
# `builder.conf`.  (ln -s example-configs/templates.conf builder.conf)
#
# To use the `setup` script, just run `setup` in the qubes-builder root
# directory.  A series of dialogs will be presented prompting various
# configuration available and then all build configuration files will
# automatically be generated based on the options selected.
#
# `setup` can be re-run again at any time to change configuration options.
# Previous options selected will be retained to allow quick switching of
# branches, templates to build, etc.
#
# Setup uses the following as markers to indicate where to place configuration
# values:
#     [=setup section start=] - Start inserting on the next line
#     [=setup section end=] - Stop insert mode
#
# Anything between these markers will be replaced, therefore:
#     - do not place any user configurations within these markers, or those
#       configurations will be replaced next time setup is run
#     - do not remove or modify the markers or setup will be unable to function
#
# -----------------------------------------------------------------------------
#            CONFIGURATION FILES INCLUDED WITH THIS CONFIGURATION
# -----------------------------------------------------------------------------
# Other configuration files are also included to offer maximum flexibility.  To
# determine which configuration files are actually being included when using
# this configuration file as a base, use the `about` target:
#   `make about`
#
# The other configuration files included (if they exist which some of them are
# automatically generated by `setup`) are as follows:
# - example-configs/qubes-os-r2.conf: If RELEASE == 2; Default Release 2
#   configuration file
# - example-configs/qubes-os-master.conf: If RELEASE == 3; Default Release 3
#   configuration file
# - override.conf: `setup` will also offer to include `override.conf` if one
#   exists.  More information on `overrides` below.
# - example-configs/extended-rules.conf: Contains extra targets mostly for
#   building templates
#
# -----------------------------------------------------------------------------
#                            ADDITIONAL OVERRIDES
# -----------------------------------------------------------------------------
# Instead of directly modifying this or any other `default` configuration
# file, an override.conf file can be placed in the `qubes-builder` root
# directory.  `setup` will offer to include this file if it exists.
#
# The `override.conf` file can contain overrides to most any configuration
# option such as BRANCH, DEBUG, VERBOSE, etc.
#
# If you create `overrides` that are specific to a release version or custom
# branch you are working on, `setup` will also be able to identify overrides
# specific to the release and or branch.
#
# To create release / branch specific `overrides`, create an override
# configuration file and place it in the `example-configs` directory named
# as follows:
#   1) example-configs/r2-feature_branch-override.conf
#      example-configs/r3-master-override.conf
#
#   2) example-configs/r3-feature_branch-override.conf
#      example-configs/r3-master-override.conf
#
#   3) example-configs/feature_branch-override.conf
#      example-configs/master-override.conf
#
#   4) example-configs/override.conf
#
#   5) override.conf
#
# Option 1 above would offer to include the override configuration file if you
# selected to build for Release 2 and are currently in the `feature_branch`
# branch.
#
# Option 2 is the same as Option 1 except for Release 3.
#
# Option 3 would use the same configuration override for both Release 2 and 3
# if you are currently in the `feature_branch` branch.
#
# If there is no release / branch specific override configuration and
# override.conf exists as in options 4, that will be available to select.
#
# Finally, an override.conf file in the `qubes-builder` root directory
# overrides all the above examples.
#
#
# A few additional notes and caveats on overrides:
#
# - The dialog to choose an override configuration is only presented on the
#   initial run of `setup`.  Once a `builder.conf` file created, there will be
#   no further prompts.  As indicated above, `setup` initially soft links
#   `examples-config/templates.conf` to `builder.conf`.  To overcome
#   this limitation, simply delete the `builder.conf` soft link and then the
#   override prompt will become available again when you re-run `setup`.
#
# - The `setup` script soft links any override configuration within the
#   examples-config directory to overrides.conf.  It will allow any soft linked
#   override to be replaced with a newly selected override option, but will not
#   allow an existing `override.conf` regular file to be overwritten that is
#   in the `qubes-builder` root directory.
#
# -----------------------------------------------------------------------------
# All lines which begins with "#" are treated as comments
# Assignments can be made with VAR_NAME="VALUE"

# [=setup info start=]
################################################################################
#
# Qubes Release: 4.1
# Source Prefix: QubesOS/qubes- (repo)
#
# Master Configuration File(s):
# qubes-os-master.conf builder.conf Makefile
#
# builder.conf copied from:
# /home/user/qubes-builder/example-configs/templates.conf
#
################################################################################
# [=setup info stop=]

RELEASE := 4.1

# SSH_ACCESS is used by `setup` to determine if ssh access mode was selected and
# will re-write the GIT_BASEURL and GIT_PREFIX variables to use ssh mode.
SSH_ACCESS := 0
GIT_BASEURL := https://github.com
GIT_PREFIX := QubesOS/qubes-

# Fetch repositories with depth=1
GIT_CLONE_FAST ?= 1

# A Qubes master configuration file will be included based on selected RELEASE
#
# A copy of BUILDER_PLUGINS will be made and restored since the BUILDER_PLUGIN
# variable gets over-written in qubes-os-master.conf.
_ORIGINAL_BUILDER_PLUGINS := $(BUILDER_PLUGINS)
ifeq ($(RELEASE), 2)
  -include example-configs/qubes-os-r2.conf
else ifeq ($(RELEASE), 3)
  -include example-configs/qubes-os-r3.0.conf
else ifeq ($(RELEASE), 3.1)
  -include example-configs/qubes-os-r3.1.conf
else ifeq ($(RELEASE), 3.2)
  -include example-configs/qubes-os-r3.2.conf
else ifeq ($(RELEASE), 4.0)
  -include example-configs/qubes-os-r4.0.conf
else
  -include example-configs/qubes-os-master.conf
endif
BUILDER_PLUGINS := $(_ORIGINAL_BUILDER_PLUGINS) $(BUILDER_PLUGINS)

# [=setup plugins start=]

# Enabled BUILDER_PLUGINS
BUILDER_PLUGINS :=
BUILDER_PLUGINS += builder-archlinux

# [=setup plugins stop=]

# Put all the enabled plugins into components to download them. But avoid
# duplicates
_temp_components := $(COMPONENTS)
COMPONENTS += $(filter-out $(_temp_components), $(BUILDER_PLUGINS))

DEBUG = 0
VERBOSE = 0
NO_SIGN = 1

DIST_DOM0 ?= fc20

# Only build templates (comment out or set to '0' to build all of Qubes).
TEMPLATE_ONLY ?= 1

################################################################################
#             S A L T   M A N A G E M E N T   O P T I O N S
################################################################################
# MGMT_SALT_ONLY - Build only mgmt-salt COMPONENTS
#  Only mgmt-salt components will bw built when issuing 'make qubes[-vm/dom0]
#  which is useful for developing.
#
# Set 1 to enable building only salt-mgmt COMPONENTS or clear value to build
# all qubes components including mgmt-salt.
# Default: novalue
#MGMT_SALT_ONLY = 1

# MGMT_SALT_COMPONENTS_USER - Custom mgmt-salt user components
#   Add any extra user based mgmt-salt formula components to include in build.
# Default: novalue
#MGMT_SALT_COMPONENTS_USER =

################################################################################
#                     L I S T   O F   D I S T   V M ' S
################################################################################
# Available template flavors may be added the the template build by appending
# `+flavor_name`

# [=setup dists start=]
ifneq "$(SETUP_MODE)" "1"

  # Enabled DISTS_VMs
  DISTS_VM :=
  DISTS_VM += archlinux+minimal

endif
# [=setup dists stop=]

# List of all build template variations that will be offered in the 'setup'
# DISTS_VM dialog to be able to choose from
ifeq "$(SETUP_MODE)" "1"
  DISTS_VM :=
  DISTS_VM += fc33
  DISTS_VM += fc33+minimal
  DISTS_VM += fc33+fullyloaded
  DISTS_VM += fc33+xfce
  DISTS_VM += fc34
  DISTS_VM += fc34+minimal
  DISTS_VM += fc34+fullyloaded
  DISTS_VM += fc34+xfce
  DISTS_VM += fc35
  DISTS_VM += fc35+minimal
  DISTS_VM += fc35+fullyloaded
  DISTS_VM += fc35+xfce
  DISTS_VM += fc36
  DISTS_VM += fc36+minimal
  DISTS_VM += fc36+fullyloaded
  DISTS_VM += fc36+xfce
  DISTS_VM += centos7
  DISTS_VM += centos7+minimal
  DISTS_VM += centos7+xfce
  DISTS_VM += buster
  DISTS_VM += buster+minimal
  DISTS_VM += buster+gnome
  DISTS_VM += bullseye
  DISTS_VM += bullseye+minimal
  DISTS_VM += bullseye+gnome
  DISTS_VM += focal
  DISTS_VM += focal+desktop
  DISTS_VM += archlinux
  DISTS_VM += archlinux+minimal
endif

################################################################################
#                     T E M P L A T E   A L I A S
################################################################################
# TEMPLATE_ALIAS can be used to choose a shorter name in DISTS_VM that
# include some other TEMPLATE_FLAVORs.  A TEMPLATE_LABEL will automatically
# be created if one does not exist that will use the alias name as the
# tempalte name.  Plus signs (+) will be converted to hyphens (-).
ifneq (,$(findstring jessie, $(DISTS_VM))$(findstring stretch, $(DISTS_VM)))

  TEMPLATE_ALIAS += jessie:jessie+standard
  TEMPLATE_ALIAS += jessie+gnome:jessie+gnome+standard
  TEMPLATE_ALIAS += jessie+minimal:jessie+minimal+no-recommends

  TEMPLATE_ALIAS += stretch:stretch+standard
  TEMPLATE_ALIAS += stretch+gnome:stretch+gnome+standard
  TEMPLATE_ALIAS += stretch+minimal:stretch+minimal+no-recommends
endif

################################################################################
#                 T E M P L A T E   C O N F I G U R A T I O N
################################################################################
# TEMPLATE_LABEL allows control over the final template name.  There is a limit
# of 31 characters for the final template name
#
# TEMPLATE_LABE += <DIST_VM name as listed above>:<desired final template name>
TEMPLATE_LABEL ?=
TEMPLATE_LABEL += stretch:debian-9
TEMPLATE_LABEL += stretch+standard:debian-9

# Location of templates flavors that are not in default location.
# Example: wheezy+whonix-gateway would normally be in
#          $$$$TEMPLATE_SCRIPTS/wheezy+whonix-gateway
#   -or-   $$$$TEMPLATE_SCRIPTS/wheezy
#          (Don't Place in {curly} brackets; ending curly gets cut off
TEMPLATE_FLAVOR_DIR :=
TEMPLATE_FLAVOR_DIR += +gnome:$$$$TEMPLATE_SCRIPTS/gnome
TEMPLATE_FLAVOR_DIR += +flash:$$$$TEMPLATE_SCRIPTS/flash
TEMPLATE_FLAVOR_DIR += +desktop:$$$$TEMPLATE_SCRIPTS/desktop
TEMPLATE_FLAVOR_DIR += +firmware:$$$$TEMPLATE_SCRIPTS/firmware

################################################################################
#                  T E M P L A T E   C O M P O N E N T S
################################################################################
# Contains a list of components when only building templates.  Note the build
# order is very important
TEMPLATE :=

TEMPLATE += $(BUILDER_PLUGINS)

TEMPLATE += vmm-xen
TEMPLATE += core-vchan-xen
ifneq ($(RELEASE), 2)
  TEMPLATE += core-qubesdb
endif
ifeq (,$(filter $(RELEASE), 3.2 4.0))
  TEMPLATE += core-qrexec
endif
TEMPLATE += linux-utils
ifneq (,$(findstring buster, $(DISTS_VM))) 
  TEMPLATE += python-xcffib
endif
TEMPLATE += core-agent-linux
TEMPLATE += gui-common
TEMPLATE += gui-agent-linux
TEMPLATE += app-linux-split-gpg
TEMPLATE += app-thunderbird
TEMPLATE += app-linux-pdf-converter
TEMPLATE += app-linux-img-converter
TEMPLATE += app-linux-input-proxy
TEMPLATE += app-linux-usb-proxy
TEMPLATE += app-linux-snapd-helper
TEMPLATE += app-shutdown-idle
TEMPLATE += app-yubikey
TEMPLATE += $(MGMT_COMPONENTS)
TEMPLATE += meta-packages
TEMPLATE += linux-template-builder

################################################################################
#            O V E R R I D E   B R A N C H   L O C A T I O N S
################################################################################
# Not yet available in 'QubesOS' repo
GIT_URL_template_whonix = $(GIT_BASEURL)/Whonix/qubes-template-whonix.git
GIT_URL_template_kali = $(GIT_BASEURL)/fepitre/qubes-template-kali.git

################################################################################
#         U S E   Q U B E S   P A C K A G E S   R E P O S I T O R I E S
################################################################################
# For building just few selected packages, it's very useful to download
# pre-built qubes-specific dependencies from `{yum,deb}.qubes-os.org`.
# This is especially true for gcc, which takes several hours to build.

# USE_QUBES_REPO_VERSION = $(RELEASE)
USE_QUBES_REPO_TESTING = 0

################################################################################
#                        M I S C E L L A N E O U S
################################################################################
# Qubes-builder deps
DEPENDENCIES ?=
DEPENDENCIES += git rpmdevtools rpm-build createrepo perl-Digest-MD5 \
                perl-Digest-SHA systemd-container

# Additional for debian template
DEPENDENCIES += debootstrap dpkg-dev

# for ./setup
DEPENDENCIES += python3-sh dialog

# Uncomment the the following to enable override.conf include.  Setup will
# automatically enable it only if an override is available and selected by
# user to enable.
#INCLUDE_OVERRIDE_CONF ?= true
ifdef INCLUDE_OVERRIDE_CONF
  -include override.conf
endif

.PHONY: about release
about::
	@echo "builder.conf"

release:
	@echo "$(RELEASE)"

# vim: filetype=make
```

</details>