### PR TITLE
Fix failed tarball resolution

### DIFF
--- a/scripts/00_prepare.sh
+++ b/scripts/00_prepare.sh
@@ -8,7 +8,7 @@ if [[ -n "${REPO_PROXY+x}" ]]; then
 fi
 ARCHLINUX_PLUGIN_DIR="${ARCHLINUX_PLUGIN_DIR:-"${SCRIPTSDIR}/.."}"
 ARCHLINUX_SRC_PREFIX="${ARCHLINUX_SRC_PREFIX:-https://mirrors.edge.kernel.org/archlinux}"
-BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha1sums.txt | grep -o "archlinux-bootstrap-[0-9.]*-x86_64.tar.gz")
+BOOTSTRAP_TARBALL=$(wget -qO- "$ARCHLINUX_SRC_PREFIX"/iso/latest/sha256sums.txt | grep -o "archlinux-bootstrap-[0-9.]*-x86_64.tar.gz")
 
 BOOTSTRAP_URL="${ARCHLINUX_SRC_PREFIX}/iso/latest/${BOOTSTRAP_TARBALL}"
 


### PR DESCRIPTION
The tarball was found using the "sha1sums" file, upstream replaced this with "sha256sums". Thus the download failed.