### PR TITLE
Deal with empty pkgs-for-template when building a template

### DIFF
--- a/scripts/04_install_qubes.sh
+++ b/scripts/04_install_qubes.sh
@@ -22,7 +22,7 @@ echo "  --> Updating Qubes custom repository..."
 # Repo Add need packages to be added in the right version number order as it only keeps the last entered package version
 # shellcheck disable=SC2016
 "${SCRIPTSDIR}/arch-chroot-lite" "$INSTALLDIR" /bin/sh -c \
-    'cd /tmp/qubes-packages-mirror-repo; for pkg in `ls -v pkgs/*.pkg.tar.zst`; do repo-add pkgs/qubes.db.tar.gz "$pkg"; done;'
+    'cd /tmp/qubes-packages-mirror-repo; repo-add pkgs/qubes.db.tar.gz; for pkg in `ls -v pkgs/*.pkg.tar.zst`; do [ -f "$pkg" ] && repo-add pkgs/qubes.db.tar.gz "$pkg"; done;'
 chown -R --reference="$PACMAN_CUSTOM_REPO_DIR" "$PACMAN_CUSTOM_REPO_DIR"
 
 echo "  --> Registering Qubes custom repository..."


### PR DESCRIPTION
It should be possible to build a template with just online repositories.
Template build scripts try to use local repository anyway, so ensure it
has proper metadata, even when it's empty.