### PR TITLE
Enable Qubes package repository on template

### DIFF
--- a/template_archlinux/04_install_qubes.sh
+++ b/template_archlinux/04_install_qubes.sh
@@ -92,6 +92,11 @@ run_pacman -S --noconfirm qubes-vm-dependencies
 echo "  --> Installing recommended qubes apps"
 run_pacman -S --noconfirm qubes-vm-recommended
 
+if [ -z "$USE_QUBES_REPO_VERSION" ]; then
+    echo "  --> Installing repository qubes package..."
+    run_pacman -S --noconfirm qubes-vm-repo
+fi
+
 echo "  --> Updating template fstab file..."
 cat >> "${INSTALL_DIR}/etc/fstab" <<EOF
 #


### PR DESCRIPTION
Related #56 changes are already incorporated into `qubes-vm-repo` and have been used since a long time when `USE_QUBES_REPO_VERSION` is set. This PR installs the package after other qubes packages in case it hasn't been installed.