### PR TITLE
Add SIGINT/SIGTERM handler to loop operations

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -63,7 +63,7 @@ echo "  --> Installing core pacman packages..."
 export PACMAN_CACHE_MOUNT_DIR="${BOOTSTRAP_DIR}/mnt/var/cache/pacman"
 # shellcheck disable=SC2016
 "${TEMPLATE_CONTENT_DIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/sh -c \
-    'for i in 1 2 3 4 5; do ALL_PROXY=$1 http_proxy=$1 https_proxy=$1 pacstrap /mnt base && exit 0; done' sh "$REPO_PROXY"
+    'trap break SIGINT SIGTERM; for i in 1 2 3 4 5; do ALL_PROXY=$1 http_proxy=$1 https_proxy=$1 pacstrap /mnt base && exit 0; done' sh "$REPO_PROXY"
 unset PACMAN_CACHE_MOUNT_DIR
 
 touch "${INSTALL_DIR}/.prepared_base"

--- a/template_archlinux/04_install_qubes.sh
+++ b/template_archlinux/04_install_qubes.sh
@@ -54,7 +54,7 @@ echo "Server = file:///tmp/qubes-packages-mirror-repo/pkgs " | sudo tee -a "$INS
 
 run_pacman () {
     "${TEMPLATE_CONTENT_DIR}/arch-chroot-lite" "$INSTALL_DIR" /bin/sh -c \
-        'proxy=$1; shift; for i in 1 2 3 4 5; do ALL_PROXY=$proxy http_proxy=$proxy https_proxy=$proxy "$@" && exit; done; exit 1' sh "$REPO_PROXY" pacman "$@"
+        'proxy=$1; shift; trap break SIGINT SIGTERM; for i in 1 2 3 4 5; do ALL_PROXY=$proxy http_proxy=$proxy https_proxy=$proxy "$@" && exit; done; exit 1' sh "$REPO_PROXY" pacman "$@"
 }
 
 echo "  --> Synchronize resolv.conf..."


### PR DESCRIPTION
Related: 

https://github.com/QubesOS/qubes-builder-archlinux/pull/57#issuecomment-1049122553 

#58: Closed PR as original files were moved, and as well because pacman already has a [sighandler](https://gitlab.archlinux.org/pacman/pacman/-/blob/master/src/pacman/sighandler.c#L54) and any trap in the outer shell (`arch-chroot-lite`) doesn't get executed, hence the need to declare the trap inside.