### PR TITLE
fix: NO_PROXY=127.0.0.1

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -63,7 +63,7 @@ echo "  --> Installing core pacman packages..."
 export PACMAN_CACHE_MOUNT_DIR="${BOOTSTRAP_DIR}/mnt/var/cache/pacman"
 # shellcheck disable=SC2016
 "${TEMPLATE_CONTENT_DIR}/arch-chroot-lite" "$BOOTSTRAP_DIR" /bin/sh -c \
-    'trap break SIGINT SIGTERM; for i in 1 2 3 4 5; do ALL_PROXY=$1 http_proxy=$1 https_proxy=$1 pacstrap /mnt base && exit 0; done' sh "$REPO_PROXY"
+    'trap break SIGINT SIGTERM; for i in 1 2 3 4 5; do ALL_PROXY=$1 http_proxy=$1 https_proxy=$1 NO_PROXY=127.0.0.1 pacstrap /mnt base && exit 0; done' sh "$REPO_PROXY"
 unset PACMAN_CACHE_MOUNT_DIR
 
 touch "${INSTALL_DIR}/.prepared_base"

--- a/template_archlinux/04_install_qubes.sh
+++ b/template_archlinux/04_install_qubes.sh
@@ -21,7 +21,7 @@ else
     PACMAN_CUSTOM_REPO_DIR="${PACKAGES_DIR}"
 fi
 
-export PACMAN_CACHE_DIR PACMAN_CUSTOM_REPO_DIR "ALL_PROXY=$REPO_PROXY"
+export PACMAN_CACHE_DIR PACMAN_CUSTOM_REPO_DIR "ALL_PROXY=$REPO_PROXY" NO_PROXY=127.0.0.1
 
 echo "  --> Enabling x86 repos..."
 su -c "echo '[multilib]' >> $INSTALL_DIR/etc/pacman.conf"
@@ -62,12 +62,12 @@ echo "Server = file:///tmp/qubes-packages-mirror-repo/pkgs " | sudo tee -a "$INS
 
 run_pacman () {
     "${TEMPLATE_CONTENT_DIR}/arch-chroot-lite" "$INSTALL_DIR" /bin/sh -c \
-        'proxy=$1; shift; trap break SIGINT SIGTERM; for i in 1 2 3 4 5; do ALL_PROXY=$proxy http_proxy=$proxy https_proxy=$proxy "$@" && exit; done; exit 1' sh "$REPO_PROXY" pacman "$@"
+        'proxy=$1; shift; trap break SIGINT SIGTERM; for i in 1 2 3 4 5; do ALL_PROXY=$proxy http_proxy=$proxy https_proxy=$proxy NO_PROXY=127.0.0.1 "$@" && exit; done; exit 1' sh "$REPO_PROXY" pacman "$@"
 }
 
 run_pacman_single () {
     "${TEMPLATE_CONTENT_DIR}/arch-chroot-lite" "$INSTALL_DIR" /bin/sh -c \
-        'proxy=$1; shift; trap break SIGINT SIGTERM; ALL_PROXY=$proxy http_proxy=$proxy https_proxy=$proxy "$@"' sh "$REPO_PROXY" pacman "$@"
+        'proxy=$1; shift; trap break SIGINT SIGTERM; ALL_PROXY=$proxy http_proxy=$proxy https_proxy=$proxy NO_PROXY=127.0.0.1 "$@"' sh "$REPO_PROXY" pacman "$@"
 }
 
 echo "  --> Synchronize resolv.conf..."


### PR DESCRIPTION
otherwise requests to repos listening on localhost will be passed via the proxy, which we generally don't want and makes for a confusing afternoon.

Related:
- https://github.com/QubesOS/qubes-core-agent-linux/pull/564
- https://github.com/QubesOS/qubes-builderv2/pull/189