### PR TITLE
Update default packages

### DIFF
--- a/template_archlinux/packages.list
+++ b/template_archlinux/packages.list
@@ -27,12 +27,11 @@ noto-fonts-emoji
 
 # Gnome
 gnome-settings-daemon
-gtk-engines
 gvfs
 lxappearance
 
 # XFCE
-leafpad
+mousepad
 thunar
 thunar-volman
 xfce4-terminal


### PR DESCRIPTION
- gtk-engines isn't there anymore, and also shouldn't be installed
  manually (only by dependency if anything needs it)
- leafpad isn't in Arch anymore, replace with mousepad as listed in the
  official xfce4-goodies group: https://archlinux.org/groups/x86_64/xfce4-goodies/